### PR TITLE
Fix deployment guide to use unzip over tbz2

### DIFF
--- a/documentation/oo_deployment_guide_vm.adoc
+++ b/documentation/oo_deployment_guide_vm.adoc
@@ -25,10 +25,10 @@ wget https://mirror.openshift.com/pub/origin-server/release/2/images/openshift-o
 
 == Unpack VM files
 
-The download package is a bzip2 compressed tar archive. Unpack it with tar:
+The download package is a compressed zip file. Unpack it with unzip:
 
 ----
-tar -xjvf openshift-origin.tbz2
+unzip openshift-origin.zip
 ----
 
 This can take quite a while.  The files being uncompressed are pretty

--- a/documentation/oo_deployment_guide_vm.adoc
+++ b/documentation/oo_deployment_guide_vm.adoc
@@ -338,7 +338,7 @@ openshift@broker.openshift.local's password:
 At this point the user has access to the `rhc` command line tools for
 managing OpenShift.
 
-See the link:oo_user_guide.txt[OpenShift User's Guide]
+See the link:oo_user_guide.html[OpenShift User's Guide]
 
 == Summary
 

--- a/documentation/oo_deployment_guide_vm.html
+++ b/documentation/oo_deployment_guide_vm.html
@@ -726,11 +726,11 @@ uncompressed RAW disk file (Linux only).</p>
 <h2 id="unpack-vm-files"><a class="anchor" href="#unpack-vm-files"></a>2. Unpack VM files</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>The download package is a bzip2 compressed tar archive. Unpack it with tar:</p>
+<p>The download package is a compressed zip file. Unpack it with unzip:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre>tar -xjvf openshift-origin.tbz2</pre>
+<pre>unzip openshift-origin.zip</pre>
 </div>
 </div>
 <div class="paragraph">

--- a/documentation/oo_deployment_guide_vm.html
+++ b/documentation/oo_deployment_guide_vm.html
@@ -1169,7 +1169,7 @@ openshift@broker.openshift.local's password:
 managing OpenShift.</p>
 </div>
 <div class="paragraph">
-<p>See the <a href="oo_user_guide.txt">OpenShift User&#8217;s Guide</a></p>
+<p>See the <a href="oo_user_guide.html">OpenShift User&#8217;s Guide</a></p>
 </div>
 </div>
 </div>


### PR DESCRIPTION
Section 2 of the deployment guide states that the download package is in tbz2 format.  Actual format is zip.  This patch replaces references to 'tbz2' with 'zip' and replaces the unpack command with an appropriate command for zip.
