### PR TITLE
Need help section no longer pertinent with latest trusted builds

### DIFF
--- a/geard/deploy_with_geard.html
+++ b/geard/deploy_with_geard.html
@@ -176,14 +176,6 @@ ctr-rockmongo-1.service - Container rockmongo-1
           <li>Open a browser and authenticate with RockMongo at <a href="http://localhost:6060/index.php">http://localhost:6060/index.php</a> with default credentials (user: admin, password: admin)</li>
           <li>Interact with your MongoDB instance by creating databases and documents!</li>          
         </ul> 
-        <h4>Need help?</h4>       
-        <p>
-          RockMongo attempts to connect to MongoDB on start-up of the container.  If you are not able to connect to MongoDB because the RockMongo container initialized first, then you will need to restart the web container using the following steps:
-        </p>
-        <ul>
-          <li><code>sudo gear stop rockmongo-1</code></li>
-          <li><code>sudo gear start rockmongo-1</code></li>
-        </ul>
       </div>
     </section>
     <section><div class="container">


### PR DESCRIPTION
Start-up order of RockMongo and MongoDb are no longer needed on centos based images.
