### PR TITLE
Updated redirects to refer directly to M4 AsciiDoc-based docs sources

### DIFF
--- a/documentation/oo_administration_guide.md
+++ b/documentation/oo_administration_guide.md
@@ -2,5 +2,5 @@
 layout: page
 title: OpenShift Origin Documentation Legacy Redirect
 redirect_to:
-  - http://docs.openshift.org/origin-m4/oo_administration_guide.html
+  - https://github.com/openshift/origin-server/tree/master/documentation/oo_administration_guide.adoc
 ---

--- a/documentation/oo_build_environment_guide.md
+++ b/documentation/oo_build_environment_guide.md
@@ -2,5 +2,5 @@
 layout: page
 title: OpenShift Origin Documentation Legacy Redirect
 redirect_to:
-  - http://docs.openshift.org/origin-m4/oo_build_environment_guide.html
+  - https://github.com/openshift/origin-server/tree/master/documentation/oo_build_environment_guide.adoc
 ---

--- a/documentation/oo_cartridge_developers_guide.md
+++ b/documentation/oo_cartridge_developers_guide.md
@@ -2,5 +2,5 @@
 layout: page
 title: OpenShift Origin Documentation Legacy Redirect
 redirect_to:
-  - http://docs.openshift.org/origin-m4/oo_cartridge_developers_guide.html
+  - https://github.com/openshift/origin-server/tree/master/documentation/oo_cartridge_developers_guide.adoc
 ---

--- a/documentation/oo_cartridge_guide.md
+++ b/documentation/oo_cartridge_guide.md
@@ -2,5 +2,5 @@
 layout: page
 title: OpenShift Origin Documentation Legacy Redirect
 redirect_to:
-  - http://docs.openshift.org/origin-m4/oo_cartridge_guide.html
+  - https://github.com/openshift/origin-server/tree/master/documentation/oo_cartridge_guide.adoc
 ---

--- a/documentation/oo_client_tools_installation_guide.md
+++ b/documentation/oo_client_tools_installation_guide.md
@@ -2,5 +2,5 @@
 layout: page
 title: OpenShift Origin Documentation Legacy Redirect
 redirect_to:
-  - http://docs.openshift.org/origin-m4/oo_client_tools_installation_guide.html
+  - https://github.com/openshift/origin-server/tree/master/documentation/oo_client_tools_installation_guide.adoc
 ---

--- a/documentation/oo_contributors_guide.md
+++ b/documentation/oo_contributors_guide.md
@@ -2,5 +2,5 @@
 layout: page
 title: OpenShift Origin Documentation Legacy Redirect
 redirect_to:
-  - http://docs.openshift.org/origin-m4/oo_contributors_guide.html
+  - https://github.com/openshift/origin-server/tree/master/documentation/oo_contributors_guide.adoc
 ---

--- a/documentation/oo_deployment_guide_comprehensive.md
+++ b/documentation/oo_deployment_guide_comprehensive.md
@@ -2,5 +2,5 @@
 layout: page
 title: OpenShift Origin Documentation Legacy Redirect
 redirect_to:
-  - http://docs.openshift.org/origin-m4/oo_deployment_guide_comprehensive.html
+  - https://github.com/openshift/origin-server/tree/master/documentation/oo_deployment_guide_comprehensive.adoc
 ---

--- a/documentation/oo_deployment_guide_puppet.md
+++ b/documentation/oo_deployment_guide_puppet.md
@@ -2,5 +2,5 @@
 layout: page
 title: OpenShift Origin Documentation Legacy Redirect
 redirect_to:
-  - http://docs.openshift.org/origin-m4/oo_deployment_guide_puppet.html
+  - https://github.com/openshift/origin-server/tree/master/documentation/oo_deployment_guide_puppet.adoc
 ---

--- a/documentation/oo_deployment_guide_vagrant.md
+++ b/documentation/oo_deployment_guide_vagrant.md
@@ -2,5 +2,5 @@
 layout: page
 title: OpenShift Origin Documentation Legacy Redirect
 redirect_to:
-  - http://docs.openshift.org/origin-m4/oo_deployment_guide_vagrant.html
+  - https://github.com/openshift/origin-server/tree/master/documentation/oo_deployment_guide_vagrant.adoc
 ---

--- a/documentation/oo_deployment_guide_vm.md
+++ b/documentation/oo_deployment_guide_vm.md
@@ -2,5 +2,5 @@
 layout: page
 title: OpenShift Origin Documentation Legacy Redirect
 redirect_to:
-  - http://docs.openshift.org/origin-m4/oo_deployment_guide_vm.html
+  - https://github.com/openshift/origin-server/tree/master/documentation/oo_deployment_guide_vm.adoc
 ---

--- a/documentation/oo_install_users_guide.md
+++ b/documentation/oo_install_users_guide.md
@@ -2,5 +2,5 @@
 layout: page
 title: OpenShift Origin Documentation Legacy Redirect
 redirect_to:
-  - http://docs.openshift.org/origin-m4/oo_install_users_guide.html
+  - https://github.com/openshift/origin-server/tree/master/documentation/oo_install_users_guide.adoc
 ---

--- a/documentation/oo_m4_release_notes.md
+++ b/documentation/oo_m4_release_notes.md
@@ -2,5 +2,5 @@
 layout: page
 title: OpenShift Origin Documentation Legacy Redirect
 redirect_to:
-  - http://docs.openshift.org/origin-m4/oo_m4_release_notes.html
+  - https://github.com/openshift/origin-server/tree/master/documentation/oo_m4_release_notes.adoc
 ---

--- a/documentation/oo_notes_building_rpms_from_source.md
+++ b/documentation/oo_notes_building_rpms_from_source.md
@@ -2,5 +2,5 @@
 layout: page
 title: OpenShift Origin Documentation Legacy Redirect
 redirect_to:
-  - http://docs.openshift.org/origin-m4/oo_notes_building_rpms_from_source.html
+  - https://github.com/openshift/origin-server/blob/openshift-origin-release-4/documentation/oo_notes_building_rpms_from_source.adoc
 ---

--- a/documentation/oo_notes_running_a_local_ddns.md
+++ b/documentation/oo_notes_running_a_local_ddns.md
@@ -2,5 +2,5 @@
 layout: page
 title: OpenShift Origin Documentation Legacy Redirect
 redirect_to:
-  - http://docs.openshift.org/origin-m4/oo_notes_running_a_local_ddns.html
+  - https://github.com/openshift/origin-server/tree/master/documentation/oo_notes_running_a_local_ddns.adoc
 ---

--- a/documentation/oo_system_architecture_guide.md
+++ b/documentation/oo_system_architecture_guide.md
@@ -2,5 +2,5 @@
 layout: page
 title: OpenShift Origin Documentation Legacy Redirect
 redirect_to:
-  - http://docs.openshift.org/origin-m4/oo_system_architecture_guide.html
+  - https://github.com/openshift/origin-server/tree/master/documentation/oo_system_architecture_guide.adoc
 ---

--- a/documentation/oo_troubleshooting_guide.md
+++ b/documentation/oo_troubleshooting_guide.md
@@ -2,5 +2,5 @@
 layout: page
 title: OpenShift Origin Documentation Legacy Redirect
 redirect_to:
-  - http://docs.openshift.org/origin-m4/oo_troubleshooting_guide.html
+  - https://github.com/openshift/origin-server/tree/master/documentation/oo_troubleshooting_guide.adoc
 ---

--- a/documentation/oo_user_guide.md
+++ b/documentation/oo_user_guide.md
@@ -2,5 +2,5 @@
 layout: page
 title: OpenShift Origin Documentation Legacy Redirect
 redirect_to:
-  - http://docs.openshift.org/origin-m4/oo_user_guide.html
+  - https://github.com/openshift/origin-server/tree/master/documentation/oo_user_guide.adoc
 ---


### PR DESCRIPTION
@Miciah and / or @tiwillia please review. I believe that elinks and curl based redirects fail because this GitHub-based jekyll-related forwarding mechanism uses meta redirects rather than server-based 301 responses. Regardless, at least these are now pointing to a meaningful endpoint.
